### PR TITLE
Adjust Rollup configuration to fix example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .idea
 .vscode
-dist/*.map
+dist/
 node_modules/
 coverage

--- a/build/rollup.config.js
+++ b/build/rollup.config.js
@@ -7,12 +7,14 @@ export default {
   input: "src/PicaEditor.vue",
   output: {
     name: "PicaEditor",
-    exports: "named",
+    format: "umd",
+    exports: "default",
     globals: {
       vue: "Vue",
       codemirror: "CodeMirror",
     },
   },
+  external: ["vue", "codemirror"],
   plugins: [
     commonjs(),
     vue({
@@ -20,6 +22,8 @@ export default {
       compileTemplate: true,
     }),
     css({ output: "dist/pica-editor.css" }),
-    babel(),
+    babel({
+      babelHelpers: "bundled",
+    }),
   ],
 }


### PR DESCRIPTION
The issue was that the previous config bundled the component as an ES Module with named exports. If we use UMD with default exports, it works fine.

I also added `external` to suppress warnings (it's weird that the warnings still show even though the externals are defined in `output.globals` already), and a babel config (also to suppress a warning).